### PR TITLE
Add answers file to template.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
           # to have a live connection to compile the sample model, but unfortunately
           # dbt seems to require it.
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-      - uses: actions/setup-python@v3
       - name: Setup git
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -46,7 +45,7 @@ jobs:
       - name: Install dependencies 
         run: |
           pip install copier poetry
-          poetry config virtualenvs.create false
+          poetry config virtualenvs.in-project true
         # TODO: once we are on dbt-snowflake 1.5, no need to pipe to a file, we can
         # just use $SNOWFLAKE_PRIVATE_KEY
       - name: Set up private key

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -31,16 +31,16 @@ for TARGET in Snowflake BigQuery; do
     poetry install --with dev
 
     # Run quality checks
-    pre-commit run --all-files
+    poetry run pre-commit run --all-files
 
     # Verify that the docs build
     pushd transform
-    dbt deps
-    dbt docs generate
+    poetry run dbt deps
+    poetry run dbt docs generate
     popd
 
     cp -r transform/target docs/dbt_docs
-    mkdocs build
+    poetry run mkdocs build
 
     popd
 done

--- a/{{project_name}}/{{_copier_conf.answers_file}}.jinja
+++ b/{{project_name}}/{{_copier_conf.answers_file}}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+{{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
This is something I had missed previously. If we include the answers to the template generator in the generated repo, it is possible to apply *updates* to the template to the project, well after it has been generated from the project.

I'm not sure exactly how well it would work in practice, but it is one of the selling points of copier, and I don't see any harm in including it.