### PR TITLE
Add subdirectory meta

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -9,6 +9,11 @@ PROJECT_NAME="sample-project"
 # Run copier.
 for TARGET in Snowflake BigQuery; do
     DIRECTORY=${PROJECT_NAME}-${TARGET}
+
+    # Enter the new project
+    mkdir -p $DIRECTORY
+    pushd $DIRECTORY
+
     copier copy \
         --data project_name=$DIRECTORY \
         --data friendly_project_name="$FRIENDLY_PROJECT_NAME" \
@@ -17,10 +22,7 @@ for TARGET in Snowflake BigQuery; do
         --data license=MIT \
         --data dbt_target=$TARGET \
         --data dbt_profile_name="default" \
-        caldata-infrastructure-template/ . 
-
-    # Enter the new project
-    pushd $DIRECTORY
+        ../caldata-infrastructure-template/ . 
 
     # Initialize git
     git init

--- a/copier.yml
+++ b/copier.yml
@@ -1,6 +1,7 @@
 _envops:
     lstrip_blocks: true
     trim_blocks: true
+_subdirectory: "{% raw %}{{project_name}}{% endraw %}"
 _exclude:
   - "copier.yaml"
   - "copier.yml"

--- a/copier.yml
+++ b/copier.yml
@@ -11,10 +11,6 @@ _exclude:
   - ".git"
   - ".DS_Store"
   - ".svn"
-  - "/ci"
-  - "/.github"
-  - "/LICENSE"
-  - "/README.md"
 
 # Questions
 friendly_project_name:


### PR DESCRIPTION
This is more work on the template to ensure that we can apply updates from here to downstream projects (i.e., the projects that were rendered from this). It makes sure that the `{{project_name}}` directory is the proper root upon applying updates. Without this it was annoyingly re-rendering the template into a sub-directory, rather than applying updates in place.

An alternative approach would be to unnest the directory structure here (everything in `{{project_name}}` goes to the root), but then we'd have to deal with conflicts in, e.g., the `.github/` directories. So I view this as the less annoying fix.