### PR TITLE
Update usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Start with a Python environment. Install `copier`:
 python -m pip install copier
 ```
 
+Create a directory into which the project will be rendered:
+
+```bash
+mkdir <your-project-name>
+cd <your-project-name>
+```
+
 Create a new project using the copier command-line tool, with HTTPS:
 ```bash
 copier copy https://github.com/cagov/caldata-infrastructure-template .
@@ -33,7 +40,6 @@ This will ask you a series of questions, the answers to which will be used to po
 Once the project is rendered, you should initialize it as a git repository:
 
 ```bash
-cd <your-project-name>
 git init
 git add .
 git commit -m "Initial commit"
@@ -58,7 +64,45 @@ Using the dbt project with BigQuery requires the following setup steps:
 
 ### Snowflake setup
 
-**TODO**
+The projects generated from our infrastructure template need read access to the
+Snowflake account in order to do two things from GitHub actions:
+
+1. Verify that dbt models in branches compile and pass linter checks
+1. Generate dbt docs upon merge to `main`.
+
+The terraform configurations deployed above create two service accounts
+for GitHub actions, a production one for docs and a dev one for CI checks.
+
+#### Add key pairs to the GitHub service accounts
+
+This repository assumes two service accounts in Snowflake for usage with GitHub Actions.
+Set up key pairs for the two GitHub actions service accounts
+(`GITHUB_ACTIONS_SVC_USER_DEV` and `GITHUB_ACTIONS_SVC_USER_PRD`) following the instructions given
+[here](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-authentication).
+
+#### Set up GitHub actions secrets
+
+In order for the service accounts to be able to connect to your Snowflake account
+you need to configure secrets in GitHub actions
+From the repository page, go to "Settings", then to "Secrets and variables", then to "Actions".
+
+Add the following repository secrets:
+
+| Variable | Value |
+|----------|-------|
+| `SNOWFLAKE_ACCOUNT` | new account locator |
+| `SNOWFLAKE_USER_DEV` | `GITHUB_ACTIONS_SVC_USER_DEV` |
+| `SNOWFLAKE_USER_PRD` | `GITHUB_ACTIONS_SVC_USER_PRD` |
+| `SNOWFLAKE_PRIVATE_KEY_DEV` | dev service account private key |
+| `SNOWFLAKE_PRIVATE_KEY_PRD` | prd service account private key |
+
+### Enable GitHub pages for the repository
+
+The repository must have GitHub pages enabled in order for it to deploy and be viewable.
+
+1. From the repository page, go to "Settings", then to "Pages".
+1. Under "GitHub Pages visibility" select "Private" (unless the project is public!).
+1. Under "Build and deployment" select "Deploy from a branch" and choose "gh-pages" as your branch.
 
 ## Testing
 


### PR DESCRIPTION
#21 had an unintended consequence for how new projects are rendered from the template: now you have to create the project directory first. This updates the docs to reflect that.

Fixes https://github.com/cagov/data-infrastructure/pull/236#discussion_r1383656105

While I'm here, I'm also adding some setup docs for Snowflake.