### PR TITLE
Turn of `processes` flag in sqlfluff

### DIFF
--- a/{{project_name}}/.pre-commit-config.yaml
+++ b/{{project_name}}/.pre-commit-config.yaml
@@ -31,5 +31,5 @@ repos:
         description: "Lints sql files with `SQLFluff`"
         types: [sql]
         require_serial: true
-        entry: poetry run sqlfluff fix --show-lint-violations --processes 0 --nocolor --disable-progress-bar --force
+        entry: poetry run sqlfluff fix --show-lint-violations --nocolor --disable-progress-bar
         pass_filenames: true

--- a/{{project_name}}/.sqlfluff
+++ b/{{project_name}}/.sqlfluff
@@ -1,6 +1,6 @@
 [sqlfluff]
 # For some reason this can only be set in the root directory, cf
-# https://docs.sqlfluff.com/en/stable/configuration.html#nesting.
+# https://docs.sqlfluff.com/en/stable/configuration/setting_configuration.html#nesting
 # Other config parameters are set in the dbt project directory, as
 # that's where dbt cloud looks for them.
 templater = dbt


### PR DESCRIPTION
Some systems seem to have problems with the processes flag, and it's not needed here.

Follow-up to #51 